### PR TITLE
Upgrade fox-aws to ~> 3.6, refactor and update gems to support Ruby 3

### DIFF
--- a/capistrano-ec2.gemspec
+++ b/capistrano-ec2.gemspec
@@ -27,10 +27,10 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "capistrano", "~> 3.0"
-  spec.add_dependency "fog-aws", "~> 0.13.0"
+  spec.add_dependency "capistrano", "~> 3.15"
+  spec.add_dependency "fog-aws", "~> 3.6"
 
-  spec.add_development_dependency "bundler", "~> 1.12"
-  spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "bundler", "~> 2.4"
+  spec.add_development_dependency "rake", "~> 13.0"
+  spec.add_development_dependency "rspec", "~> 3.10"
 end

--- a/lib/capistrano/ec2/capistrano_monkey_patch.rb
+++ b/lib/capistrano/ec2/capistrano_monkey_patch.rb
@@ -1,4 +1,5 @@
 require 'fog/aws'
+require 'forwardable'
 
 module Capistrano
   class Configuration
@@ -58,6 +59,7 @@ module Capistrano
 
   module DSL
     module Env
+      extend Forwardable
       def_delegators :env, :for_each_ec2_server
     end
   end


### PR DESCRIPTION
In this PR, I've updated `capistrano-ec2` dependencies to primarily support IMDSv2 via the `fog` gem and did some small refactoring for better compatibility with Ruby 3.2.1.

Dependency upgrades ― Upgraded critical dependencies to support IMDSv2 and ensure compatibility with Ruby 3.2.1. This includes moving to capistrano ~> 3.15, fog-aws ~> 3.6 (specifically 3.6.4 for IMDSv2 support), bundler ~> 2.4, rake ~> 13.0, and rspec ~> 3.10.

The `untaint` method issue ― Addressed the `NoMethodError` for `untaint` by updating Bundler and Ruby versions. This issue arose because the untaint method, used in older versions of Bundler, is not supported in Ruby 3.2.1.

The `Forwardable` requirement ― Added require 'forwardable' and extended the DSL module to fix issues with `def_delegators` in our environment.

To-do: needs some more thorough testing and potentially add a test that mocks AWS response for `#for_each_ec2_server`, since the specs currently only check `expect(Capistrano::Ec2::VERSION).not_to be nil`.

